### PR TITLE
Feature: Pipeline & steps can make entries in a log file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   ],
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@skypilot/sugarbowl": "^3.1.0"
+    "@skypilot/sugarbowl": "^3.2.0"
   }
 }

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -1,9 +1,14 @@
 import type { Integer } from '@skypilot/common-types';
 
 import type { Dict, MaybePromise } from 'src/lib/types';
+import { Logger } from 'src/logger/Logger';
 import type { Pipeline } from './Pipeline';
 
-type Handler<Context> = ((context?: Partial<Context>) => MaybePromise<Partial<Context> | void>);
+interface Handles {
+  logger: Logger;
+}
+
+type Handler<Context> = ((context: Partial<Context>, handles: Handles) => MaybePromise<Partial<Context> | void>);
 
 interface PipelineStepParams<Context> {
   index: Integer;
@@ -31,8 +36,8 @@ export class Step<Context extends Dict> {
     this.pipeline = pipeline;
   }
 
-  async run(): Promise<void> {
-    const result = await this.handle(this.pipeline.context);
+  async run(context: Partial<Context>, handles: Handles): Promise<void> {
+    const result = await this.handle(context, handles);
     if (result) {
       this.pipeline.updateContext(result);
     }

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -16,6 +16,7 @@ export interface StepParams<Context> {
 }
 
 export class Step<Context extends Dict> {
+  index: Integer; // index in the parent's array of steps
   name: string;
 
   private readonly handle: Handler<Context>;
@@ -25,6 +26,7 @@ export class Step<Context extends Dict> {
     const { pipeline, handle, index, name = index.toString() } = stepParams;
 
     this.handle = handle || (context => context);
+    this.index = index;
     this.name = name;
     this.pipeline = pipeline;
   }

--- a/src/lib/getLastItem.ts
+++ b/src/lib/getLastItem.ts
@@ -1,0 +1,17 @@
+interface GetLastItemOptions<D> {
+  defaultValue?: D;
+}
+
+export function getLastItem<T>(items: ReadonlyArray<T>, options?: { defaultValue: undefined }): T | undefined;
+export function getLastItem<T, D extends T | undefined>(items: ReadonlyArray<T>, options: GetLastItemOptions<D>): T | D;
+
+// Return the last item in the array, or null if the array is empty
+export function getLastItem<T, D extends T>(
+  items: ReadonlyArray<T>, options: GetLastItemOptions<T> = {}
+): T | D | undefined {
+  const { defaultValue } = options;
+  if (items.length === 0) {
+    return defaultValue !== undefined ? defaultValue : undefined;
+  }
+  return items.slice(-1)[0];
+}

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import fs from 'fs';
+import path from 'path';
+import type { Integer } from '@skypilot/common-types';
+import { consoleIf, getLastItem, includeIf } from '@skypilot/sugarbowl';
+import beautify from 'json-beautify';
+
+import { toUtcDateTimeText } from './toUtcDateTimeText';
+
+interface AddOptions {
+  sectionBreakAfter?: boolean;
+  sectionBreakBefore?: boolean;
+  prefix?: string;
+  runLevel?: Integer;
+}
+
+interface LoggerParams {
+  logDir?: string;
+  logFileName?: string;
+  verbose?: boolean;
+}
+
+export class Logger {
+  indentWidth = 2;
+  sectionBreak = '-'.repeat(20);
+  verbose: boolean;
+
+  private readonly createdAt = new Date();
+  private log: string[] = [];
+  private readonly logDir: string;
+  private readonly logFileName: string;
+
+  constructor(params: LoggerParams = {}) {
+    // If the file name is empty, saving to a file via `write` is disabled
+    const { logDir = 'logs', logFileName = '', verbose = false } = params;
+    this.logDir = logDir;
+    this.logFileName = logFileName;
+    this.verbose = verbose;
+  }
+
+  add(message: string | Record<string, any>, options: AddOptions = {}): void {
+    const { prefix = '', runLevel = 0, sectionBreakAfter, sectionBreakBefore } = options;
+
+    const indent = this.computeIndent(runLevel);
+
+    const messageBlock = typeof message === 'string'
+      ? message
+      // @ts-ignore // ignore the erroneous typing in `json-beautify`
+      : beautify(message, null, 2, 100);
+    const lines = messageBlock.split('\n');
+
+    const resolvedPrefix = (typeof message === 'string' || !prefix)
+      ? prefix
+      : `${prefix}: `; // TODO: Use the same behaviour for objects as for strings?
+    const formattedLines: string[] = [];
+    if (sectionBreakBefore) {
+      this.addSectionBreak(runLevel);
+    }
+    lines.forEach((line, index) => {
+      const formattedLine = `${indent}${index ? '' : resolvedPrefix}${line}`;
+      formattedLines.push(formattedLine);
+    });
+    this.log.push(...formattedLines);
+    if (sectionBreakAfter) {
+      this.addSectionBreak(runLevel);
+    }
+    consoleIf(this.verbose)(formattedLines.join('\n'));
+  }
+
+  // TODO: Allow a section heading to be added
+  addSectionBreak(runLevel: Integer = 1): void {
+    if (!(getLastItem(this.log, { defaultValue: '' }).includes(this.sectionBreak))) {
+      this.log.push(this.computeIndent(runLevel) + this.sectionBreak);
+    }
+  }
+
+  computeIndent(runLevel: Integer = 1): string {
+    const indentLevel = Math.max(0, runLevel - 1);
+    return ' '.repeat(this.indentWidth * indentLevel);
+  }
+
+  display(): void {
+    // eslint-disable-next-line no-console
+    console.log(this.format());
+  }
+
+  // TODO: Refactor so that `addSectionBreak` can be used to generate the output
+  format(): string {
+    return [
+      `Started at ${toUtcDateTimeText(this.createdAt)}`,
+      '-'.repeat(20),
+      ...this.log,
+      // Add a section break, but only if the previous line wasn't as section break
+      ...includeIf(
+        !getLastItem(this.log, { defaultValue: '' }).includes(this.sectionBreak),
+        this.sectionBreak
+      ),
+      `Finished at ${toUtcDateTimeText()}`,
+    ].join('\n');
+  }
+
+  get(): string[] {
+    return this.log;
+  }
+
+  getPaths(): { fullDirPath: string; fullFilePath: string } {
+    const fullDirPath = this.logDir ? path.resolve(this.logDir) : '';
+    const fullFilePath = this.logFileName ? path.join(fullDirPath, this.logFileName) : '';
+    return { fullDirPath, fullFilePath };
+  }
+
+  write(): void {
+    // Do nothing if no file name was given
+    if (!this.logFileName) {
+      return;
+    }
+
+    const { fullDirPath, fullFilePath } = this.getPaths();
+
+    fs.mkdirSync(fullDirPath, { recursive: true });
+    fs.writeFileSync(fullFilePath, this.format());
+  }
+}

--- a/src/logger/__tests__/Logger.unit.test.ts
+++ b/src/logger/__tests__/Logger.unit.test.ts
@@ -1,0 +1,49 @@
+import { Logger } from '../Logger';
+
+describe('Logger class', () => {
+  describe('add(message: string)', () => {
+    it('should add the message to the log', () => {
+      const logger = new Logger();
+      const messages = [
+        '1st message',
+        '2nd message',
+      ];
+
+      logger.add(messages[0]);
+      logger.add(messages[1]);
+
+      expect(logger.get()).toStrictEqual(messages);
+    });
+
+    it('given a `runLevel` option, should indent the message 2 spaces per run level', () => {
+      const logger = new Logger();
+      const messages = [
+        'run level: 1',
+        'run level: 2',
+        { runLevel: 3 },
+      ];
+
+      messages.forEach((message, index) => {
+        logger.add(message, { runLevel: index + 1 });
+      });
+
+      expect(logger.get()).toStrictEqual([
+        'run level: 1',
+        '  run level: 2',
+        '    { "runLevel": 3 }',
+      ]);
+    });
+
+    it('given a `prefix` option with a string, should prepend the prefix to the message', () => {
+      const logger = new Logger();
+      const message = 'Message';
+      const prefix = 'Prefix: ';
+
+      logger.add(message, { prefix });
+
+      expect(logger.get()).toStrictEqual([
+        'Prefix: Message',
+      ]);
+    });
+  });
+});

--- a/src/logger/toUtcDateTimeText.ts
+++ b/src/logger/toUtcDateTimeText.ts
@@ -1,0 +1,8 @@
+/* Return a string representation of date & time of the given value (or the current date & time, if no value is given)
+ * in UTC (universal coordinated time, a.k.a. GMT) */
+export function toUtcDateTimeText(date: Date = new Date()): string {
+  return [
+    date.toISOString().replace('T', ' ').slice(0, -5),
+    'UTC',
+  ].join(' ');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,10 +1195,10 @@
   resolved "https://registry.yarnpkg.com/@skypilot/eslint-config-typescript/-/eslint-config-typescript-1.7.0.tgz#66c1996fa8a1083e6895dac347322e8e40ac0102"
   integrity sha512-IKY2XjOyErasndv5+BoE3lMnXXXeAjF/GUL7C/gFhO7QEuOcUpsVoLENVgGZ0wmHmgeYsLejeUboqWWszFMUpg==
 
-"@skypilot/sugarbowl@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@skypilot/sugarbowl/-/sugarbowl-3.1.0.tgz#3babb10e51504712d6112cbda2c7f194ba51bd68"
-  integrity sha512-bxdgPu0b6hvNE788QxgT3+o0FNsoY5D/WSueNuP437s1dnOY+5DZ7nmk1FMrp74rp5f5iZVtF+WfKzQZnlTkcw==
+"@skypilot/sugarbowl@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@skypilot/sugarbowl/-/sugarbowl-3.2.0.tgz#79c2988d7938adb5e6e6c9ad7394b0ca5efb19f0"
+  integrity sha512-lSZWxuXUhfnlU/G5UDT73jrty62SECA7aKPCZAurJHsIWBweCT6FhwyOaWGudjIrRPumxr7c880ue+XXcUTTiQ==
   dependencies:
     json-beautify "^1.1.1"
 


### PR DESCRIPTION
The pipeline can now record log entries and write the log to a file. The logger is exposed at `Pipeline.logger`.

Basic API:
- `add(message: string | object, { indentLevel?: Integer })`: Add a message with optional indentation
- `addSectionBreak()`: Add a line of dashes to separate sections of the log
- `display()`: Display the log
- `get()`: Get the array of log entries
- `getPaths()`: Get the absolute paths of the log directory & the log file
- `write()`: Write the log to the log file
