### PR TITLE
Feature: Enable logging of errors occurring in a step

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   ],
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@skypilot/sugarbowl": "^3.2.0"
+    "@skypilot/sugarbowl": "^3.2.0",
+    "serialize-error": "^8.0.1"
   }
 }

--- a/src/core/Pipeline.ts
+++ b/src/core/Pipeline.ts
@@ -1,5 +1,6 @@
 import type { Integer } from '@skypilot/common-types';
 import { includeIf, inflectQuantity } from '@skypilot/sugarbowl';
+import { serializeError } from 'serialize-error';
 
 import type { Dict } from 'src/lib/types';
 import { Logger } from 'src/logger/Logger';
@@ -82,13 +83,10 @@ export class Pipeline<Context extends Dict> {
       await step.run(this.context, { logger: this.logger })
         .catch(error => {
           // Save the error to the log and write the log, so that existing log entries aren't lost
-          const { name, message, stack, ...otherProps } = error;
-          this.logger.add({
-            ...otherProps,
-            name,
-            message,
-            stack: error.stack.split('\n'),
-          }, { prefix: 'Error' });
+          // const { stack, ...errorRest } = error;
+          const serializedError = serializeError(error);
+          const { stack, ...otherProps } = serializedError;
+          this.logger.add({ ...otherProps, stack: stack.split('\n') }, { prefix: 'Error' });
           this.logger.write();
 
           // TODO: Build in optional error handling with "skip" and "stop" options

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,6 +5071,13 @@ semver@^7.2.1, semver@^7.3.2:
   dependencies:
     lru-cache "^6.0.0"
 
+serialize-error@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.0.1.tgz#7a67f8ecbbf28973b5a954a2852ff9f4eef52d99"
+  integrity sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==
+  dependencies:
+    type-fest "^0.20.2"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
Made two significant changes to `Pipeline.run`:

- If an error occurs, the error is entered into the log
- The log file is written to disk before processing terminates

Previously, the `logger.write()` command was never reached if an error occurred in a step.