### PR TITLE
Export Logger class & types

### DIFF
--- a/src/__tests__/validate-exports.app.test.ts
+++ b/src/__tests__/validate-exports.app.test.ts
@@ -1,6 +1,7 @@
 import * as actualExports from '../index';
 
 const intendedExports: string[] = [
+  'Logger',
   'Pipeline',
 ];
 

--- a/src/core/Pipeline.ts
+++ b/src/core/Pipeline.ts
@@ -7,15 +7,15 @@ import { Logger } from 'src/logger/Logger';
 import { Step } from './Step';
 import type { StepParams } from './Step';
 
-interface ExcludeSteps {
+export interface ExcludeSteps {
   excludeSteps?: string[]; includeSteps?: undefined;
 }
 
-interface IncludeSteps {
+export interface IncludeSteps {
   excludeSteps?: undefined; includeSteps?: string[];
 }
 
-interface CorePipelineRunOptions {
+export interface CorePipelineRunOptions {
   slice?: Slice;
   verbose?: boolean;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,1 @@
+export { Pipeline } from './Pipeline';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { Pipeline } from 'src/core/Pipeline';
+export * from './core';
+export * from './logger';

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,0 +1,1 @@
+export { Logger } from './Logger';


### PR DESCRIPTION
- `Logger` class is now exported for use
- More types are exported, which may fix reported import problems