### PR TITLE
Rewrite context typings to resolve TS errors

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,14 @@
 export type Dict<Value = any> = Record<string, Value>;
 
 export type MaybePromise<T> = T | Promise<T>;
+
+type Merge<A, B> = {
+  [K in keyof A]: K extends keyof B ? B[K] : A[K]
+} & B
+
+// For describing additive data
+export type Final<Initial, Added> = Merge<Initial, Added>;
+
+export type Fragment<Initial, Added> = Partial<Interim<Initial, Added>>
+
+export type Interim<Initial, Added> = Initial | Partial<Added>;


### PR DESCRIPTION
These changes attempt to resolve the typing issues related to initial, partial, and final contexts managed by the `Pipeline` class.