### PR TITLE
Features: Allow step dependencies with validation; allow exclusion by default

### DIFF
--- a/src/core/Pipeline.ts
+++ b/src/core/Pipeline.ts
@@ -97,13 +97,13 @@ export class Pipeline<I extends Dict, A extends Dict> {
     const [sliceStart, sliceEnd] = slice;
     const sliceParams = [sliceStart, ...includeIf(sliceEnd)];
 
-    const filter = (() => {
+    const filter = ((): ((step: Step<I, A>) => boolean) => {
       if (excludeSteps) {
-        return ({ name }: { name: string }) => !excludeSteps.includes(name);
+        return step => !excludeSteps.includes(step.name) && !step.excludeByDefault;
       } else if (includeSteps) {
-        return ({ name }: { name: string }) => includeSteps.includes(name);
+        return step => includeSteps.includes(step.name);
       } else {
-        return () => true;
+        return step => !step.excludeByDefault;
       }
     })();
 

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -11,9 +11,11 @@ export type Handler<I, A> = (context: Interim<I, A>, handles: Handles) => MaybeP
 export interface StepParams<I, A> {
   handle: Handler<I, A>;
   name: string;
+  dependsOn?: string[];
 }
 
 export class Step<I, A> {
+  dependsOn: string[]; // names of steps that must be run before this step
   name: string;
   pipeline: Pipeline<I, A>;
 
@@ -21,8 +23,9 @@ export class Step<I, A> {
 
   // TODO: When typings are correctly handled, allow the `Step` to be created independently of a `Pipeline`
   constructor(stepParams: StepParams<I, A> & { pipeline: Pipeline<I, A> }) {
-    const { pipeline, handle, name } = stepParams;
+    const { dependsOn = [], handle, name, pipeline } = stepParams;
 
+    this.dependsOn = dependsOn;
     this.handle = handle || (context => context);
     this.name = name;
     this.pipeline = pipeline;

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -1,5 +1,3 @@
-import type { Integer } from '@skypilot/common-types';
-
 import type { Fragment, Interim, MaybePromise } from 'src/lib/types';
 import type { Logger } from 'src/logger/Logger';
 import type { Pipeline } from './Pipeline';
@@ -10,28 +8,22 @@ export interface Handles {
 
 export type Handler<I, A> = (context: Interim<I, A>, handles: Handles) => MaybePromise<Fragment<I, A> | void>;
 
-interface PipelineStepParams<I, A> {
-  index: Integer;
-  pipeline: Pipeline<I, A>;
-}
-
 export interface StepParams<I, A> {
   handle: Handler<I, A>;
-  name?: string;
+  name: string;
 }
 
 export class Step<I, A> {
-  index: Integer; // index in the parent's array of steps
   name: string;
+  pipeline: Pipeline<I, A>;
 
   private readonly handle: Handler<I, A>;
-  private readonly pipeline: Pipeline<I, A>;
 
-  constructor(stepParams: StepParams<I, A> & PipelineStepParams<I, A>) {
-    const { pipeline, handle, index, name = `Unnamed step ${(index + 1).toString()}` } = stepParams;
+  // TODO: When typings are correctly handled, allow the `Step` to be created independently of a `Pipeline`
+  constructor(stepParams: StepParams<I, A> & { pipeline: Pipeline<I, A> }) {
+    const { pipeline, handle, name } = stepParams;
 
     this.handle = handle || (context => context);
-    this.index = index;
     this.name = name;
     this.pipeline = pipeline;
   }

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -9,6 +9,7 @@ export interface Handles {
 export type Handler<I, A> = (context: Interim<I, A>, handles: Handles) => MaybePromise<Fragment<I, A> | void>;
 
 export interface StepParams<I, A> {
+  excludeByDefault?: boolean;
   handle: Handler<I, A>;
   name: string;
   dependsOn?: string[];
@@ -16,6 +17,7 @@ export interface StepParams<I, A> {
 
 export class Step<I, A> {
   dependsOn: string[]; // names of steps that must be run before this step
+  excludeByDefault: boolean; // if true, don't include unless the step is explicitly named in the run options
   name: string;
   pipeline: Pipeline<I, A>;
 
@@ -23,9 +25,10 @@ export class Step<I, A> {
 
   // TODO: When typings are correctly handled, allow the `Step` to be created independently of a `Pipeline`
   constructor(stepParams: StepParams<I, A> & { pipeline: Pipeline<I, A> }) {
-    const { dependsOn = [], handle, name, pipeline } = stepParams;
+    const { dependsOn = [], excludeByDefault = false, handle, name, pipeline } = stepParams;
 
     this.dependsOn = dependsOn;
+    this.excludeByDefault = excludeByDefault;
     this.handle = handle || (context => context);
     this.name = name;
     this.pipeline = pipeline;

--- a/src/core/__tests__/Pipeline.unit.test.ts
+++ b/src/core/__tests__/Pipeline.unit.test.ts
@@ -132,6 +132,39 @@ describe('Pipeline class', () => {
     });
   });
 
+  describe('filterSteps()', () => {
+    it('when the includeSteps option is used, should exclude all other steps', () => {
+      const pipeline = new Pipeline();
+      pipeline.addStep({ handle: () => ({}) });
+
+      expect(pipeline.filterSteps({ includeSteps: [] })).toHaveLength(0);
+    });
+
+    it('steps with excludeByDefault should be excluded unless included by includeSteps', () => {
+      const pipeline = new Pipeline();
+      pipeline.addStep({ name: 'step-1', handle: () => ({ step: 1 }), excludeByDefault: true });
+      pipeline.addStep({ name: 'step-2', handle: () => ({ step: 2 }) });
+      pipeline.addStep({ name: 'step-3', handle: () => ({ step: 3 }), excludeByDefault: true });
+
+      {
+        const filteredStepNames = pipeline.filterSteps().map(step => step.name);
+        expect(filteredStepNames).toStrictEqual(['step-2']);
+      }
+      {
+        const filteredStepNames = pipeline.filterSteps({ slice: [0, 3] }).map(step => step.name);
+        expect(filteredStepNames).toStrictEqual(['step-2']);
+      }
+      {
+        const filteredStepNames = pipeline.filterSteps({ excludeSteps: ['step-3'] }).map(step => step.name);
+        expect(filteredStepNames).toStrictEqual(['step-2']);
+      }
+      {
+        const filteredStepNames = pipeline.filterSteps({ includeSteps: ['step-1', 'step-2'] }).map(step => step.name);
+        expect(filteredStepNames).toStrictEqual(['step-1', 'step-2']);
+      }
+    });
+  });
+
   describe('run()', () => {
     it('when there are no steps, should return the initial context', async () => {
       // Pipeline without context


### PR DESCRIPTION
A step can now be designated as excluded by default:

- Added the `excludeByDefault` property to the `Step` class. If true, the step can be included by the ` includeSteps` option but never as a result of the `slice` or `excludeSteps` options

Dependencies can now be declared among steps:
- Added a `Pipeline.validate` method, which checks for missing dependencies while taking into account active filters
- Validation occurs automatically at the beginning of `Pipeline.run`, and the run is aborted if validation fails
