### PR TITLE
Feature: Enable checks for missing input

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@skypilot/sugarbowl": "^3.2.0",
+    "dot-prop": "^6.0.1",
     "serialize-error": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@skypilot/common-types": "^2.2.1",
     "@skypilot/toolchain": "^5.2.2",
-    "type-fest": "^1.0.0"
+    "type-fest": "^1.0.1"
   },
   "publishConfig": {
     "access": "restricted"
@@ -51,7 +51,7 @@
   ],
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@skypilot/sugarbowl": "^3.2.0",
+    "@skypilot/sugarbowl": "^3.3.0",
     "dot-prop": "^6.0.1",
     "serialize-error": "^8.0.1"
   }

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -1,24 +1,40 @@
-import type { Fragment, Interim, MaybePromise } from 'src/lib/types';
+// IMPORTS
+import { ValidationResult } from '@skypilot/sugarbowl';
+import { has } from 'dot-prop';
+
+import { ValidationError  } from 'src/lib/classes/ValidationError';
+import type { Dict, Fragment, Interim, MaybePromise } from 'src/lib/types';
 import type { Logger } from 'src/logger/Logger';
+
 import type { Pipeline } from './Pipeline';
 
-// TODO: Possibly remove the `logger` and expect the pipeline to provide it if needd (like any other handle)
+
+// TYPES
+// TODO: Possibly remove the `logger` and expect the pipeline to provide it if needed (like any other handle)
 export interface Handles {
   logger?: Logger;
 }
 
 export type Handler<I, A> = (context: Interim<I, A>, handles: Handles) => MaybePromise<Fragment<I, A> | void>;
 
-export interface StepParams<I, A> {
-  excludeByDefault?: boolean;
-  handle: Handler<I, A>;
-  name: string;
-  dependsOn?: string[];
+export interface InputOptions {
+  required?: boolean;
+  type?: string;
 }
 
+export interface StepParams<I, A> {
+  dependsOn?: string[];
+  excludeByDefault?: boolean;
+  handle: Handler<I, A>;
+  inputs?: Dict<InputOptions>;
+  name: string;
+}
+
+// CLASS
 export class Step<I, A> {
   dependsOn: string[]; // names of steps that must be run before this step
   excludeByDefault: boolean; // if true, don't include unless the step is explicitly named in the run options
+  inputs: Dict<InputOptions>;
   name: string;
   pipeline?: Pipeline<I, A>;
 
@@ -26,21 +42,45 @@ export class Step<I, A> {
 
   // TODO: When typings are correctly handled, allow the `Step` to be created independently of a `Pipeline`
   constructor(stepParams: StepParams<I, A> & { pipeline?: Pipeline<I, A> }) {
-    const { dependsOn = [], excludeByDefault = false, handle, name, pipeline } = stepParams;
+    const { dependsOn = [], excludeByDefault = false, handle, inputs = {}, name, pipeline } = stepParams;
 
     this.dependsOn = dependsOn;
     this.excludeByDefault = excludeByDefault;
     this.handle = handle || (context => context);
+    this.inputs = inputs;
     this.name = name;
     this.pipeline = pipeline;
   }
 
   async run(context: Interim<I, A> = {}, handles: Handles = {}): Promise<Interim<I, A>> {
+    if (!this.isInputValid(context)) {
+      throw new ValidationError('Invalid input', this.validateInputs(context).messages);
+    }
     const result = await this.handle(context, handles);
     if (result) {
       this.pipeline?.updateContext(result);
       return result;
     }
     return {};
+  }
+
+  isInputValid(context: Interim<I, A>): boolean {
+    return this.validateInputs(context).success;
+  }
+
+  validateInputs(context: Interim<I, A>): ValidationResult {
+    const validationResult = new ValidationResult();
+    for (const [path, options] of Object.entries(this.inputs)) {
+      const { required } = options;
+
+      if (required && !has(context, path)) {
+        validationResult.add(
+          'error',
+          `Missing required context path '${path}'`,
+          { id: path },
+        );
+      }
+    }
+    return validationResult;
   }
 }

--- a/src/core/__tests__/Step.unit.test.ts
+++ b/src/core/__tests__/Step.unit.test.ts
@@ -29,5 +29,56 @@ describe('Step class', () => {
         step.run({}, { logger })
       ).resolves.toStrictEqual({ a: 1 });
     });
+
+    it('if input is required, should reject if the input is not provided', async () => {
+      type Initial = { input: number };
+      type Final = { input: number; output: number };
+      const step = new Step<Initial, Final>({
+        name: 'test-step',
+        handle: context => ({ output: (context.input || 0) + 1 }),
+        inputs: {
+          'input': { required: true },
+        },
+      });
+
+      await expect(step.run({ input: 1 })).resolves.not.toThrow();
+      await expect(step.run({})).rejects.toThrow('Invalid input');
+    });
+  });
+
+  describe('validateInputs', () => {
+    it('if context satisfies the inputs, should return a ValidationResult containing no events', async () => {
+      const step = new Step({
+        name: 'test-step',
+        handle: () => ({ a: 1 }),
+        inputs: {
+          'branch.leaf': { required: true },
+        },
+      });
+
+      const validationResult = step.validateInputs({ branch: { leaf: 1 } });
+      expect(validationResult.success).toBe(true);
+      expect(validationResult.errors).toHaveLength(0);
+      expect(validationResult.messages).toHaveLength(0);
+    });
+
+    it('if context does not satisfy the inputs, should return a ValidationResult containing error events', async () => {
+      const step = new Step({
+        name: 'test-step',
+        handle: () => ({ a: 1 }),
+        inputs: {
+          'branch.leaf1': { required: true },
+          'branch.leaf2': { required: true },
+        },
+      });
+
+      const validationResult = step.validateInputs({});
+      // expect(validationResult.success).toBe(false);
+      expect(validationResult.errors).toHaveLength(2);
+      expect(validationResult.messages).toStrictEqual([
+        "Error: Missing required context path 'branch.leaf1'",
+        "Error: Missing required context path 'branch.leaf2'",
+      ]);
+    });
   });
 });

--- a/src/lib/classes/ValidationError.ts
+++ b/src/lib/classes/ValidationError.ts
@@ -1,0 +1,6 @@
+// WIP: A class that allows additional error messages to be attached
+export class ValidationError extends Error {
+  constructor(message: string, public errors: string[]) {
+    super(message);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,10 +1195,10 @@
   resolved "https://registry.yarnpkg.com/@skypilot/eslint-config-typescript/-/eslint-config-typescript-1.7.0.tgz#66c1996fa8a1083e6895dac347322e8e40ac0102"
   integrity sha512-IKY2XjOyErasndv5+BoE3lMnXXXeAjF/GUL7C/gFhO7QEuOcUpsVoLENVgGZ0wmHmgeYsLejeUboqWWszFMUpg==
 
-"@skypilot/sugarbowl@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@skypilot/sugarbowl/-/sugarbowl-3.2.0.tgz#79c2988d7938adb5e6e6c9ad7394b0ca5efb19f0"
-  integrity sha512-lSZWxuXUhfnlU/G5UDT73jrty62SECA7aKPCZAurJHsIWBweCT6FhwyOaWGudjIrRPumxr7c880ue+XXcUTTiQ==
+"@skypilot/sugarbowl@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@skypilot/sugarbowl/-/sugarbowl-3.3.0.tgz#e0c9840915cb3c4a0575c88b1b01a2522308e8fa"
+  integrity sha512-8StQutrqxyG8SQWpu9rRu/jOSgRA8lBst6WbAyR/iZbO7pU9ete1bpWcvWKwB5Y8JibLDN7tB4KrKroKZ4fYyg==
   dependencies:
     json-beautify "^1.1.1"
 
@@ -5608,10 +5608,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-fest@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.0.0.tgz#4f9c2e57377545d93736165861175d108685c037"
-  integrity sha512-Q75/Kan//7GSHmyXvG5kQdLSuF+PJzOv2sc6XyhAYCvR4xoAF5qHI2mKmhkpMOtvrfn9FSh376dGaZbdWL/vgQ==
+type-fest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.0.1.tgz#2494455e65c59170ec98bdda05b7d7184f5b74ad"
+  integrity sha512-+UTPE7JT3O+sUpRroRgQAbbSfIRBwOHh+o/oruB1JJE6g6uBm3Y0D82fO3xu8VHfxJLQjeRp0PEY6mRmh/lElA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,13 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+dot-prop@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
+  dependencies:
+    is-obj "^2.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -3291,6 +3298,11 @@ is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
- Added the `isInputValid` & `validateInputs` methods to `Step`
- If input defined in `InputOptions` to a `Step` has `required: true`, `validateInputs` returns an object describing errors
- If `validateInputs` detects errors when the `Step.run()` is executed, an error is thrown