### PR TITLE
Feature: Pipeline accepts signals from steps

### DIFF
--- a/src/core/Pipeline.ts
+++ b/src/core/Pipeline.ts
@@ -62,17 +62,7 @@ export class Pipeline<I extends Dict, A extends Dict> {
   addStep(stepParams: SetOptional<StepParams<I, A>, 'name'>): this;
   addStep(stepParams: Step<I, A> | SetOptional<StepParams<I, A>, 'name'>): this {
     const stepInstance = stepParams instanceof Step
-      ? ((): Step<I, A> => {
-        if (stepParams.pipeline !== this) {
-          if (stepParams.pipeline) {
-            /* TODO: Probably the old pipeline can simply be replaced. But for now this guard is in
-             * place to help TypeScript with typings. */
-            throw new Error('The step was created in a different pipeline');
-          }
-          stepParams.pipeline = this;
-        }
-        return stepParams;
-      })()
+      ? stepParams
       : ((): Step<I, A> => {
         const { name = `step-${this.steps.length}` } = stepParams;
         if (this.steps.find(step => step.name === name)) {
@@ -136,7 +126,7 @@ export class Pipeline<I extends Dict, A extends Dict> {
         `Started step ${filteredSteps.indexOf(step) + 1}: ${step.name}`,
         { prependTimestamp: true, sectionBreakBefore: true, sectionBreakAfter: true }
       );
-      await step.run(this.context, { logger: this.logger })
+      await step.run(this.context, { logger: this.logger, pipeline: this })
         .catch(error => {
           // Save the error to the log and write the log, so that existing log entries aren't lost
           // const { stack, ...errorRest } = error;

--- a/src/core/__tests__/Pipeline.unit.test.ts
+++ b/src/core/__tests__/Pipeline.unit.test.ts
@@ -67,18 +67,6 @@ describe('Pipeline class', () => {
       expect(pipeline.steps.find(({ name }) => name === step.name)).toBe(step);
     });
 
-    it('should refuse to add a step created in a different Pipeline', () => {
-      const pipeline = new Pipeline();
-      const otherPipeline = new Pipeline();
-      const stepOutput = { a: 1 };
-
-      const step = pipeline.createStep({ name: 'test-step', handle: () => stepOutput });
-
-      expect(() => {
-        otherPipeline.addStep(step);
-      }).toThrow('The step was created in a different pipeline');
-    });
-
     it('can chain method calls', async () => {
       const pipeline = new Pipeline();
       const step1Output = { a: 1 };

--- a/src/core/__tests__/Pipeline.unit.test.ts
+++ b/src/core/__tests__/Pipeline.unit.test.ts
@@ -316,6 +316,19 @@ describe('Pipeline class', () => {
     });
   });
 
+  describe('signal(:Signal)', () => {
+    it('can accept a signal from a step', async () => {
+      const pipeline = new Pipeline();
+      pipeline.addStep({
+        handle: (_context, { pipeline }) => {
+          pipeline?.signal('StopPipeline');
+        },
+      });
+      await pipeline.run();
+      expect(pipeline.signals).toContain('StopPipeline');
+    });
+  });
+
   describe('validate(:StepFilters)', () => {
     it('when no step has a dependency, should return an empty errors array', () => {
       const pipeline = new Pipeline();


### PR DESCRIPTION
The `Pipeline` class now exposes a `signal` method, which gives steps a way to communicate with the pipeline.

The `run` method checks for the `StopPipeline` signal at the end of each step. If found, the run is halted.