### PR TITLE
Feature: Enable console display of validation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@skypilot/sugarbowl": "^3.3.0",
+    "@skypilot/sugarbowl": "^3.4.0-next.1",
     "dot-prop": "^6.0.1",
     "serialize-error": "^8.0.1"
   }

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -24,12 +24,16 @@ export interface InputOptions {
   type?: string;
 }
 
+export interface ValidationOptions {
+  logLevel?: LogLevel | null;
+}
+
 export interface StepParams<I, A> {
   dependsOn?: string[];
   excludeByDefault?: boolean;
   handle?: Handler<I, A>;
   inputs?: Dict<InputOptions>;
-  logLevel?: LogLevel;
+  logLevel?: LogLevel | null;
   name?: string;
 }
 
@@ -76,11 +80,13 @@ export class Step<I, A> {
     return {};
   }
 
-  isInputValid(context: Interim<I, A>): boolean {
-    return this.validateInputs(context).success;
+  isInputValid(context: Interim<I, A>, options: ValidationOptions = {}): boolean {
+    return this.validateInputs(context, options).success;
   }
 
-  validateInputs(context: Interim<I, A>): ValidationResult {
+  validateInputs(context: Interim<I, A>, options: ValidationOptions = {}): ValidationResult {
+    const { logLevel = this.logLevel } = options;
+
     const validationResult = new ValidationResult();
     for (const [path, options] of Object.entries(this.inputs)) {
       const { required } = options;
@@ -96,7 +102,7 @@ export class Step<I, A> {
     const { highestLevel } = validationResult;
     if (
       !isUndefined(highestLevel)
-      && ValidationResult.compareLevels(validationResult.highestLevel, this.logLevel) >= 0
+      && ValidationResult.compareLevels(validationResult.highestLevel, logLevel) >= 0
     ) {
       // eslint-disable-next-line no-console
       console[highestLevel](validationResult);

--- a/src/core/Step.ts
+++ b/src/core/Step.ts
@@ -1,5 +1,6 @@
 // IMPORTS
-import { ValidationResult } from '@skypilot/sugarbowl';
+import { isUndefined, ValidationResult } from '@skypilot/sugarbowl';
+import type { LogLevel } from '@skypilot/sugarbowl';
 import { has } from 'dot-prop';
 
 import { ValidationError  } from 'src/lib/classes/ValidationError';
@@ -28,6 +29,7 @@ export interface StepParams<I, A> {
   excludeByDefault?: boolean;
   handle?: Handler<I, A>;
   inputs?: Dict<InputOptions>;
+  logLevel?: LogLevel;
   name?: string;
 }
 
@@ -36,6 +38,7 @@ export class Step<I, A> {
   dependsOn: string[]; // names of steps that must be run before this step
   excludeByDefault: boolean; // if true, don't include unless the step is explicitly named in the run options
   inputs: Dict<InputOptions>;
+  logLevel: LogLevel | null;
   name: string;
 
   private readonly handle?: Handler<I, A>;
@@ -45,6 +48,7 @@ export class Step<I, A> {
       dependsOn = [],
       excludeByDefault = false,
       handle,
+      logLevel = 'warn',
       inputs = {},
       name = 'unnamed',
     } = stepParams;
@@ -52,6 +56,7 @@ export class Step<I, A> {
     this.dependsOn = dependsOn;
     this.excludeByDefault = excludeByDefault;
     this.handle = handle;
+    this.logLevel = logLevel;
     this.inputs = inputs;
     this.name = name;
   }
@@ -87,6 +92,14 @@ export class Step<I, A> {
           { id: path },
         );
       }
+    }
+    const { highestLevel } = validationResult;
+    if (
+      !isUndefined(highestLevel)
+      && ValidationResult.compareLevels(validationResult.highestLevel, this.logLevel) >= 0
+    ) {
+      // eslint-disable-next-line no-console
+      console[highestLevel](validationResult);
     }
     return validationResult;
   }

--- a/src/core/__tests__/Pipeline.unit.test.ts
+++ b/src/core/__tests__/Pipeline.unit.test.ts
@@ -314,6 +314,23 @@ describe('Pipeline class', () => {
 
       await expect(pipeline.run()).rejects.toThrow();
     });
+
+    it('if the StopPipeline signal is issued in a step, the pipeline should stop after that step', async () => {
+      const pipeline = new Pipeline()
+        .addStep({ name: 'step-a', handle: () => ({ a: 1 }) })
+        .addStep({
+          name: 'step-b',
+          handle: (_context, { pipeline }) => {
+            pipeline?.signal('StopPipeline');
+            return { b: 2 };
+          },
+        })
+        .addStep({ name: 'step-c', handle: () => ({ c: 3 }) });
+
+      const context = await pipeline.run();
+
+      expect(context).toStrictEqual({ a: 1, b: 2 });
+    });
   });
 
   describe('signal(:Signal)', () => {

--- a/src/core/__tests__/Step.unit.test.ts
+++ b/src/core/__tests__/Step.unit.test.ts
@@ -11,6 +11,7 @@ describe('Step class', () => {
       const step = new Step({
         name: 'test-step',
         handle: () => ({}),
+        logLevel: null, // here and in other tests, set logLevel to `null` to avoid console spam
       });
 
       expect(step).toBeInstanceOf(Step);
@@ -23,6 +24,7 @@ describe('Step class', () => {
       const step = new Step({
         name: 'test-step',
         handle: () => ({ a: 1 }),
+        logLevel: null,
       });
 
       await expect(
@@ -39,6 +41,7 @@ describe('Step class', () => {
         inputs: {
           'input': { required: true },
         },
+        logLevel: null,
       });
 
       await expect(step.run({ input: 1 })).resolves.not.toThrow();
@@ -54,6 +57,7 @@ describe('Step class', () => {
         inputs: {
           'branch.leaf': { required: true },
         },
+        logLevel: null,
       });
 
       const validationResult = step.validateInputs({ branch: { leaf: 1 } });
@@ -70,6 +74,7 @@ describe('Step class', () => {
           'branch.leaf1': { required: true },
           'branch.leaf2': { required: true },
         },
+        logLevel: null,
       });
 
       const validationResult = step.validateInputs({});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,10 +1195,10 @@
   resolved "https://registry.yarnpkg.com/@skypilot/eslint-config-typescript/-/eslint-config-typescript-1.7.0.tgz#66c1996fa8a1083e6895dac347322e8e40ac0102"
   integrity sha512-IKY2XjOyErasndv5+BoE3lMnXXXeAjF/GUL7C/gFhO7QEuOcUpsVoLENVgGZ0wmHmgeYsLejeUboqWWszFMUpg==
 
-"@skypilot/sugarbowl@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@skypilot/sugarbowl/-/sugarbowl-3.3.0.tgz#e0c9840915cb3c4a0575c88b1b01a2522308e8fa"
-  integrity sha512-8StQutrqxyG8SQWpu9rRu/jOSgRA8lBst6WbAyR/iZbO7pU9ete1bpWcvWKwB5Y8JibLDN7tB4KrKroKZ4fYyg==
+"@skypilot/sugarbowl@^3.4.0-next.1":
+  version "3.4.0-next.1"
+  resolved "https://registry.yarnpkg.com/@skypilot/sugarbowl/-/sugarbowl-3.4.0-next.1.tgz#2aeb784af89f17d0315ad112b4eddda486f796a7"
+  integrity sha512-nYN/XcljFoC7aRhKo8X064jbF7ihnn1qd8hIlfusj2kVkRL599oX9hjxGT8Wt3QtEcsmvtDv8AS03ir3TkC1BQ==
   dependencies:
     json-beautify "^1.1.1"
 


### PR DESCRIPTION
Added the `logLevel` option to `Step` constructor options. If an event's level equals or exceeds `logLevel`, the event will be displayed using `console[event.level]`